### PR TITLE
clever way to compile only changed jade, not the whole project

### DIFF
--- a/gruntfile.coffee
+++ b/gruntfile.coffee
@@ -6,11 +6,17 @@ module.exports = (grunt) ->
   # while watching, only load the dep needed to take the grunt action
   require("jit-grunt")(grunt)
 
-  # load your tasks, allows them to be in separate files for cleanliness
-  tasks = require("load-grunt-configs")(grunt, config: src: "tasks/*.coffee")
-
   # loads file paths and other build configurations
   buildConfig = require("./app.coffee")(grunt)
+
+  # load your tasks, allows them to be in separate files for cleanliness
+  tasks = require("load-grunt-configs")(grunt, config: src: [
+    "tasks/*.coffee"
+    "!tasks/jade-inheritance.coffee"
+  ])
+
+  # load special jade tool so just what changed is processed
+  require("./tasks/jade-inheritance.coffee")(grunt, buildConfig)
 
   # Merge all tasks and build config together and then init
   grunt.initConfig grunt.util._.extend(tasks, buildConfig)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-notify": "*",
     "grunt-shell": "*",
     "grunt-svgmin": "*",
+    "jade-inheritance": "^0.2.0",
     "jit-grunt": "*",
     "load-grunt-configs": "*",
     "time-grunt": "*",

--- a/tasks/jade-inheritance.coffee
+++ b/tasks/jade-inheritance.coffee
@@ -1,0 +1,21 @@
+module.exports = (grunt, config) ->
+  JadeInheritance   = require('jade-inheritance')
+  changedFiles      = []
+  base_dir          = config.app_dir
+  jade_config       = config.app_files.jade[0]
+
+  onChange = grunt.util._.debounce((->
+    dependantFiles = []
+
+    changedFiles.forEach (filename) ->
+      inheritance = new JadeInheritance filename, base_dir, basedir: base_dir
+      dependantFiles = dependantFiles.concat inheritance.files
+
+    jade_config.src = dependantFiles
+    grunt.config 'jade.compile.files', [ jade_config ]
+    changedFiles = []
+  ), 200)
+
+  grunt.event.on 'watch', (action, filepath) ->
+    changedFiles.push filepath
+    onChange()


### PR DESCRIPTION
long needed. this will speed up larger jade projects. it's curious why this behavior doesn't exist by default.